### PR TITLE
replaces the relevant metrics with the new prefix

### DIFF
--- a/bosh-lite/stub.yml
+++ b/bosh-lite/stub.yml
@@ -49,7 +49,7 @@ properties:
     api_url: https://app.datadoghq.com/api/v1/series
     api_key: API_KEY
     flush_duration_seconds: 15
-    metric_prefix: bosh.lite.datadog.nozzle.
+    metric_prefix: cloudfoundry.nozzle.
   uaa:
     url: https://uaa.bosh-lite.com
     client: datadog-firehose-nozzle

--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -25,7 +25,7 @@ properties:
     default: 57671680
   datadog.metric_prefix:
     description: "Text which will be prepended to each metric name submitted to datadog"
-    default: "datadog.nozzle."
+    default: "cloudfoundry.nozzle."
   datadog.logrotate.freq_min:
     description: "The frequency in minutes which logrotate will rotate VM logs"
     default: 5

--- a/templates/datadog-bosh2.yml
+++ b/templates/datadog-bosh2.yml
@@ -38,7 +38,7 @@ instance_groups:
         api_url: "((datadog_api))"
         api_key: "((datadog_key))"
         flush_duration_seconds: 15
-        metric_prefix: datadog.nozzle.
+        metric_prefix: cloudfoundry.nozzle.
       uaa:
         url: "((uaa_url))"
         client: "((uaa_client))"


### PR DESCRIPTION
This is the proper prefix now, others will be allowed but discouraged