### PR TITLE
We no longer need golang 1.7.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,3 @@
-golang/go1.7.4.linux-amd64.tar.gz:
-  size: 84021919
-  object_id: 2072c9e7-f3d3-45e3-7d19-89b31a32b6f6
-  sha: 2e5baf03d1590e048c84d1d5b4b6f2540efaaea1
 golang/go1.8.3.linux-amd64.tar.gz:
   size: 90029041
   object_id: 312d9ff9-1484-4ab5-7ed5-7b526cdca38f


### PR DESCRIPTION
This removes golang 1.7.4. There's no need to keep it here. Awesome!