### PR TITLE
Crop default datadog.api_url

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -14,7 +14,7 @@ properties:
     description: "Traffic controller URL"
   datadog.api_url:
     description: "The REST API Endpoint for datadog"
-    default: "https://app.datadoghq.com/api/v1/series"
+    default: "https://app.datadoghq.com/api/v1"
   datadog.api_key:
     description: "The datadog API key to use while submitting requests"
   datadog.flush_duration_seconds:


### PR DESCRIPTION
Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>

### What does this PR do?

This is so the nozzle can emit both series and events

### Additional Notes

Related to https://github.com/DataDog/datadog-firehose-nozzle/pull/11
