### PR TITLE
Updates the bosh2.0 manifest to use the correct bosh release

### DIFF
--- a/templates/datadog-bosh2.yml
+++ b/templates/datadog-bosh2.yml
@@ -38,7 +38,7 @@ instance_groups:
         api_url: "((datadog_api))"
         api_key: "((datadog_key))"
         flush_duration_seconds: 15
-        metric_prefix: datadog.nozzle.
+        metric_prefix: cloudfoundry.nozzle.
       uaa:
         url: "((uaa_url))"
         client: "((uaa_client))"

--- a/templates/datadog-bosh2.yml
+++ b/templates/datadog-bosh2.yml
@@ -3,7 +3,7 @@ name: datadog
 
 releases:
   - name: datadog-firehose-nozzle
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/datadog-firehose-nozzle-release
+    url: https://bosh.io/d/github.com/datadog/datadog-firehose-nozzle-release
     version: latest
 
 update:
@@ -23,11 +23,11 @@ instance_groups:
   azs:
   - z1
   instances: 1
-  persistent_disk_type: 5GB
+  persistent_disk_type: default
   vm_type: default
   stemcell: default
   networks:
-  - name: private
+  - name: default
   jobs:
   - name: datadog-firehose-nozzle
     release: datadog-firehose-nozzle
@@ -38,7 +38,7 @@ instance_groups:
         api_url: "((datadog_api))"
         api_key: "((datadog_key))"
         flush_duration_seconds: 15
-        metric_prefix: cloudfoundry.nozzle.
+        metric_prefix: datadog.nozzle.
       uaa:
         url: "((uaa_url))"
         client: "((uaa_client))"


### PR DESCRIPTION
- Uses the correct bosh release
- Updates some properties to just use default values. This works better when
  working with cloud configs from bosh-deployment.

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

- Uses the correct bosh release
- Updates some properties to just use default values. This works better when
  working with cloud configs from bosh-deployment.

### Motivation

I work on Cloud Foundry and needed to deploy the datadog nozzle on a bosh-lite environment.

### Testing Guidelines

You can use the bosh2 manifest to deploy to a local bosh-lite. Instructions can be found at [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment). The bosh-lite cloud config is located [here](https://github.com/cloudfoundry/bosh-deployment/tree/2172e2f222c3c59fb2c7a27726af9f24f09c285f/warden)

### Additional Notes

Nope. 
