### PR TITLE
Fixes the name of the bosh.io release path

### DIFF
--- a/templates/datadog-bosh2.yml
+++ b/templates/datadog-bosh2.yml
@@ -3,7 +3,7 @@ name: datadog
 
 releases:
   - name: datadog-firehose-nozzle
-    url: https://bosh.io/d/github.com/datadog/datadog-firehose-nozzle-release
+    url: https://bosh.io/d/github.com/DataDog/datadog-firehose-nozzle-release
     version: latest
 
 update:


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This PR fixes the bosh.io release path for datadog in the bosh 2.0 template.

Apparently `DataDog` is different from `datadog`.

### Motivation

We are using this nozzle as part of our CI pipelines. It broke, which motivated us to fix the issue. :)
