### PR TITLE
The max bytes setting was incorrect

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -23,7 +23,7 @@ properties:
     default: 15
   datadog.flush_max_bytes:
     description: "The maximum number of bytes to send per POST request"
-    default: 57671680
+    default: 2097152
   datadog.metric_prefix:
     description: "Text which will be prepended to each metric name submitted to datadog"
     default: "cloudfoundry.nozzle."


### PR DESCRIPTION
### What does this PR do?

The default max bytes setting was incorrect. It should have been much lower. This was causing payloads to not get properly split.