### PR TITLE
releases nozzle v68

### DIFF
--- a/.final_builds/jobs/datadog-firehose-nozzle/index.yml
+++ b/.final_builds/jobs/datadog-firehose-nozzle/index.yml
@@ -67,4 +67,8 @@ builds:
     version: ddb8bf489b31b2c90f472f63eb9e250b6f599a15
     blobstore_id: 0740d131-215c-4107-8e1b-13a27e79f4bd
     sha1: 0cc3ce558db61da9e362c02ba4d8021820b95ada
+  eb9b79533ef667ed7bb7fe59c2cf4c656f131d6f:
+    version: eb9b79533ef667ed7bb7fe59c2cf4c656f131d6f
+    blobstore_id: fe1cd38a-80fe-46e2-4ace-2e76e4c43c16
+    sha1: 55a0cc9553a6976af62c79c7ee4040c5125f6e30
 format-version: "2"

--- a/releases/datadog-firehose-nozzle/datadog-firehose-nozzle-68.yml
+++ b/releases/datadog-firehose-nozzle/datadog-firehose-nozzle-68.yml
@@ -1,0 +1,25 @@
+name: datadog-firehose-nozzle
+version: "68"
+commit_hash: becab51
+uncommitted_changes: true
+jobs:
+- name: datadog-firehose-nozzle
+  version: eb9b79533ef667ed7bb7fe59c2cf4c656f131d6f
+  fingerprint: eb9b79533ef667ed7bb7fe59c2cf4c656f131d6f
+  sha1: 55a0cc9553a6976af62c79c7ee4040c5125f6e30
+packages:
+- name: datadog-firehose-nozzle
+  version: 5aeecc79a7d61a49157f3f8f2cf58f9f16e8f0d2
+  fingerprint: 5aeecc79a7d61a49157f3f8f2cf58f9f16e8f0d2
+  sha1: 68bed262518528d80f85183afefe905f43befa5c
+  dependencies:
+  - golang1.9.4
+- name: golang1.9.4
+  version: 16375c0c5d6666c054253735dc3722e66bcbcb07
+  fingerprint: 16375c0c5d6666c054253735dc3722e66bcbcb07
+  sha1: 988edb6b67bc250b14709595f1753653fd353eda
+  dependencies: []
+license:
+  version: 0e57672ea6f64377156a79ca7ac2347cebaa8d27
+  fingerprint: 0e57672ea6f64377156a79ca7ac2347cebaa8d27
+  sha1: b84575d095b66db5dac4fbfa0b58b3d14e23a34c

--- a/releases/datadog-firehose-nozzle/index.yml
+++ b/releases/datadog-firehose-nozzle/index.yml
@@ -59,6 +59,8 @@ builds:
     version: "54"
   6b650fcd-294e-48ac-a844-90138ea60b41:
     version: "46"
+  7d61a673-ff01-4195-4df2-01fa13eeded5:
+    version: "68"
   80054998-18ab-4cbc-91df-50910ad1930f:
     version: "39"
   821f5f26-7b4a-4b90-8923-6ac3ca467247:


### PR DESCRIPTION
### What does this PR do?

This PR releases nozzle version 68, which includes only changes to the release itself: a flare implementation and fixing the default flush_max_bytes so that metric splitting actually works.