### PR TITLE
Revert "add options to tile"

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -238,16 +238,6 @@ forms:
     type: boolean
     default: true
     description: Enable the Trace Agent on all virtual machines
-  - name: logs_enabled
-    label: Enable Logs Agent
-    type: boolean
-    default: false
-    description: Enable the Logs Agent on all virtual machines
-  - name: strip_proc_arguments
-    label: Strip process arguments
-    type: boolean
-    default: false
-    description: This setting will strip the process arguments from the processes sent by the process agent.
 
 - name: cf-config
   label: Cloud Foundry Settings
@@ -341,7 +331,7 @@ packages:
 
 
 runtime_configs:
-  - name: datadog-agent
+  - name: datdog-agent
     runtime_config:
       releases:
         - name: datadog-agent
@@ -391,5 +381,3 @@ runtime_configs:
             ip_tag: (( .properties.ip_tag.value ))
             address_tag: (( .properties.address_tag.value ))
             trace_agent_enabled: (( .properties.trace_agent.value ))
-            logs_enabled: (( .properties.logs_enabled.value ))
-            strip_proc_arguments: (( .properties.strip_proc_arguments.value ))


### PR DESCRIPTION
Reverts DataDog/datadog-firehose-nozzle-release#59

Revert for releasing the tile without those changes. Will add them back when we do the next bosh agent release.