### PR TITLE
Add agent option `skip SSL validation` on the tile

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -148,6 +148,11 @@ forms:
   label: Datadog Agent Config
   description: Configure your Datadog Agent!
   properties:
+  - name: skip_ssl_validation
+    type: boolean
+    label: Skip SSL validation
+    default: false
+    description: Configure the Datadog agent to skip SSL validation
   - name: use_uuid_hostname
     type: boolean
     label: Use UUID Hostname
@@ -353,6 +358,7 @@ runtime_configs:
           release: datadog-agent
         properties:
           dd:
+            skip_ssl_validation: (( .properties.skip_ssl_validation.value ))
             use_dogstatsd: yes
             dogstatsd_port: 18125 # Many Cloud Foundry deployments have their own StatsD listening on port 8125
             process_agent_enabled: yes


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Add option `skip_ssl_validation` to the tile

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
