### PR TITLE
Use correct property name for enabling logs agent

### DIFF
--- a/tile/tile-history.yml
+++ b/tile/tile-history.yml
@@ -18,4 +18,10 @@ history:
 - 2.6.0
 - 2.6.1
 - 2.7.0
+<<<<<<< Updated upstream
 version: 2.8.0
+=======
+- 2.8.0
+- 2.9.0
+version: 2.9.0
+>>>>>>> Stashed changes

--- a/tile/tile-history.yml
+++ b/tile/tile-history.yml
@@ -18,10 +18,4 @@ history:
 - 2.6.0
 - 2.6.1
 - 2.7.0
-<<<<<<< Updated upstream
 version: 2.8.0
-=======
-- 2.8.0
-- 2.9.0
-version: 2.9.0
->>>>>>> Stashed changes

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -402,5 +402,5 @@ runtime_configs:
             ip_tag: (( .properties.ip_tag.value ))
             address_tag: (( .properties.address_tag.value ))
             trace_agent_enabled: (( .properties.trace_agent.value ))
-            logs_enabled: (( .properties.logs_enabled.value ))
+            enable_logs_agent: (( .properties.logs_enabled.value ))
             strip_proc_arguments: (( .properties.strip_proc_arguments.value ))


### PR DESCRIPTION
### What does this PR do?

Fix property name `dd.enable_logs_agent`

### Motivation

https://github.com/DataDog/datadog-agent-boshrelease/blob/2a3a3fddcbdc58ac2d1f23c94b6bf023825f9633/jobs/dd-agent/spec#L34

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?