### PR TITLE
Add disk check configuration option

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -267,7 +267,6 @@ forms:
   - name: disk_yaml_config
     label: Disk integration YAML configuration
     type: text
-    default: ""
     optional: true
     description: Paste here the YAML configuration of the disk integration.
 

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -254,6 +254,23 @@ forms:
     default: false
     description: This setting will strip the process arguments from the processes sent by the process agent.
 
+- name: disk-check-config
+  label: Disk integration configuration
+  description: Use this to fully configure and customize the disk integration.
+  markdown: |
+    Write here the entire YAML configuration of your configuration.
+    See [the example configuration](https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/data/conf.yaml.default)
+    for more details about the available options.
+
+    Setting this will override the disk check configuration settings in the main `Datadog Agent Config` tab.
+  properties:
+  - name: disk_yaml_config
+    label: Disk integration YAML configuration
+    type: text
+    default: ""
+    optional: true
+    description: Paste here the YAML configuration of the disk integration.
+
 - name: cf-config
   label: Cloud Foundry Settings
   description: Cloud Foundry connection details
@@ -396,6 +413,7 @@ runtime_configs:
             generate_disk_config: (( .properties.generate_disk_config.value ))
             generate_disk_config_tag_by_filesystem: (( .properties.generate_disk_config_tag_by_filesystem.value ))
             generate_disk_config_all_partitions: (( .properties.generate_disk_config_all_partitions.value ))
+            disk_yaml_config: (( .properties.disk_yaml_config.value ))
             enable_gohai: (( .properties.enable_gohai.value ))
             check_runners: (( .properties.check_runners.value ))
             forwarder_num_workers: (( .properties.forwarder_num_workers.value ))


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Provide an additional option in the tile to allow full customization of the disk check configuration

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?