### PR TITLE
Fix logrotate permissions

### DIFF
--- a/jobs/datadog-firehose-nozzle/templates/logrotate.conf.erb
+++ b/jobs/datadog-firehose-nozzle/templates/logrotate.conf.erb
@@ -5,5 +5,5 @@
   delaycompress
   copytruncate
   size=<%= p("datadog.logrotate.size") %>
+  su vcap vcap
 }
-


### PR DESCRIPTION
### What does this PR do?

Fix log rotate permissions

### Motivation

```
error: skipping "/var/vcap/sys/log/datadog-firehose-nozzle/datadog-firehose-nozzle.stderr.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?