### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.final_builds/packages/datadog-firehose-nozzle/index.yml
+++ b/.final_builds/packages/datadog-firehose-nozzle/index.yml
@@ -151,6 +151,10 @@ builds:
     version: 8735cf62eed7818497038fdf727c4eaaec2cf677
     blobstore_id: 7544237f-6d9a-4fa5-a2be-916655302cf0
     sha1: 156deabc9c31de110f937dd26cf849099e8ea26b
+  8ca853b1adfd2a08758c58dba708145c0bb2e871:
+    version: 8ca853b1adfd2a08758c58dba708145c0bb2e871
+    blobstore_id: f67bd29c-e274-4c41-4544-e7669fcaa65c
+    sha1: 675fe36ac17b1a3c72eec25d5fac9e5b17891191
   8f4d7a067c93f0a4a1f37c126cb8097af0a303f3:
     version: 8f4d7a067c93f0a4a1f37c126cb8097af0a303f3
     blobstore_id: d8aaa014-e22e-450e-99f8-fc8821d64d0c

--- a/.final_builds/packages/golang1.13/index.yml
+++ b/.final_builds/packages/golang1.13/index.yml
@@ -1,0 +1,6 @@
+builds:
+  08bfaa0e4bec3dbce9bb712948f98b4c88ac16d0:
+    version: 08bfaa0e4bec3dbce9bb712948f98b4c88ac16d0
+    blobstore_id: de14f1aa-aeb3-4fbb-4757-b396af5c312d
+    sha1: 500ef60fbae3abe8c7c9034702ebe488cd8d9ebc
+format-version: "2"

--- a/releases/datadog-firehose-nozzle/datadog-firehose-nozzle-76.yml
+++ b/releases/datadog-firehose-nozzle/datadog-firehose-nozzle-76.yml
@@ -1,0 +1,25 @@
+name: datadog-firehose-nozzle
+version: "76"
+commit_hash: e74781a
+uncommitted_changes: true
+jobs:
+- name: datadog-firehose-nozzle
+  version: b9a16aee2c202539cf9060e1b7909ade740936e7
+  fingerprint: b9a16aee2c202539cf9060e1b7909ade740936e7
+  sha1: 5516b3f66d41bbd7cfe2b452469cdc704a72f276
+packages:
+- name: datadog-firehose-nozzle
+  version: 8ca853b1adfd2a08758c58dba708145c0bb2e871
+  fingerprint: 8ca853b1adfd2a08758c58dba708145c0bb2e871
+  sha1: 675fe36ac17b1a3c72eec25d5fac9e5b17891191
+  dependencies:
+  - golang1.13
+- name: golang1.13
+  version: 08bfaa0e4bec3dbce9bb712948f98b4c88ac16d0
+  fingerprint: 08bfaa0e4bec3dbce9bb712948f98b4c88ac16d0
+  sha1: 500ef60fbae3abe8c7c9034702ebe488cd8d9ebc
+  dependencies: []
+license:
+  version: 0e57672ea6f64377156a79ca7ac2347cebaa8d27
+  fingerprint: 0e57672ea6f64377156a79ca7ac2347cebaa8d27
+  sha1: b84575d095b66db5dac4fbfa0b58b3d14e23a34c

--- a/releases/datadog-firehose-nozzle/index.yml
+++ b/releases/datadog-firehose-nozzle/index.yml
@@ -57,6 +57,8 @@ builds:
     version: "65"
   539b4d1e-edb4-45de-b08b-99f9757eb158:
     version: "3"
+  57727e82-fce3-4530-481a-4ab659f7b63a:
+    version: "76"
   58fd9d13-cec2-497e-862e-6a540771a0c5:
     version: "6"
   66249870-2ae7-4f65-81b9-5fd2e08726b1:

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -5,7 +5,7 @@ type glide >/dev/null 2>&1 || (echo "installing Glide" && curl https://glide.sh/
 
 export GOPATH="$(pwd)/src/datadog-firehose-nozzle/:$GOPATH"
 
-DEFAULT_NOZZLE_VERSION=1.1.0
+DEFAULT_NOZZLE_VERSION=1.2.0
 
 NOZZLE_VERSION=${NOZZLE_VERSION:-$DEFAULT_NOZZLE_VERSION}
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bump to use nozzle version 1.2. 0

### Motivation

Get the latest and greatest features for release. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
