### PR TITLE
Bump default nozzle version to 1.3.0

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -5,7 +5,7 @@ type glide >/dev/null 2>&1 || (echo "installing Glide" && curl https://glide.sh/
 
 export GOPATH="$(pwd)/src/datadog-firehose-nozzle/:$GOPATH"
 
-DEFAULT_NOZZLE_VERSION=1.2.0
+DEFAULT_NOZZLE_VERSION=1.3.0
 
 NOZZLE_VERSION=${NOZZLE_VERSION:-$DEFAULT_NOZZLE_VERSION}
 


### PR DESCRIPTION
### What does this PR do?

Bump default nozzle version to 1.3.0

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
