### PR TITLE
Add option to enable/disable app metadata prefix in app metrics

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -151,3 +151,6 @@ properties:
   nozzle.enable_advanced_tagging:
     default: false
     description: Wheter or not to send extra tags such as `sidecar_present` and `sidecar_count` for app metrics.
+  nozzle.enable_metadata_app_metrics_prefix:
+    default: true
+    description: Wheter or not to add "label/" or "annotation/" prefix to app metadata tags in app metrics.

--- a/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
+++ b/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
@@ -93,7 +93,8 @@ JSON.pretty_generate(
     "DCAEnabled" => p("nozzle.dca_enabled", false),
     "DCAUrl"=>  dca_full_url,
     "DCAToken" => p("nozzle.dca_token", ""),
-    "EnableAdvancedTagging" => p("nozzle.enable_advanced_tagging")
+    "EnableAdvancedTagging" => p("nozzle.enable_advanced_tagging"),
+    "EnableMetadataAppMetricsPrefix" => p("nozzle.nozzle.enable_metadata_app_metrics_prefix")
 )
 
 %>

--- a/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
+++ b/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
@@ -94,7 +94,7 @@ JSON.pretty_generate(
     "DCAUrl"=>  dca_full_url,
     "DCAToken" => p("nozzle.dca_token", ""),
     "EnableAdvancedTagging" => p("nozzle.enable_advanced_tagging"),
-    "EnableMetadataAppMetricsPrefix" => p("nozzle.nozzle.enable_metadata_app_metrics_prefix")
+    "EnableMetadataAppMetricsPrefix" => p("nozzle.enable_metadata_app_metrics_prefix")
 )
 
 %>


### PR DESCRIPTION
Wheter or not to add `label/` or `annotation/` prefix to app metadata tags in app metrics.