### PR TITLE
Add scheme prefix handling for the property `nozzle.dca_url`

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -146,7 +146,7 @@ properties:
     description: Token to connect to the cluster agent.
   nozzle.dca_url:
     default: ""
-    description: URL of the cluster agent.
+    description: URL of the cluster agent, the scheme will be added automatically in case it is not included.
   nozzle.dca_port:
     default: 5005
     description: Port to connect to the cluster agent.

--- a/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
+++ b/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
@@ -53,6 +53,10 @@
   if p("nozzle.dca_url") && p("nozzle.dca_port")
     dca_full_url = "#{p("nozzle.dca_url")}:#{p("nozzle.dca_port")}"
   end
+  
+  if !dca_full_url.start_with?('http://', 'https://')
+    dca_full_url = "https://#{dca_full_url}"
+  end
 %>
 
 <%=


### PR DESCRIPTION
Automatically add `https://` to the `nozzle.dca_url` property if no valid scheme is found in the given url (http, https).