### PR TITLE
Update gitlab ECR image to registry.ddbuild.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
 
 datadog-firehose-nozzle-release:
   stage: deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:v6554890-8eae026
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v48815877-9bfad02c
   tags: ["runner:main"]
   when: manual
   script:


### PR DESCRIPTION
Similar to [Changed ECR -> registry.ddbuild.io and updated build images](https://github.com/DataDog/datadog-agent-boshrelease/pull/220).