### PR TITLE
Fix `nozzle.num_workers` property name

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -120,7 +120,7 @@ properties:
   nozzle.app_metrics:
     description: "Turn on grabbing of app metrics (may substantially increase load)"
     default: true
-  nozzle.workers:
+  nozzle.num_workers:
     description: "The number of worker threads to use"
     default: 4
   nozzle.grab_interval:


### PR DESCRIPTION
### What does this PR do?

Fixed the incorrect property name in the spec.

### Description of the Change

The template (https://github.com/DataDog/datadog-firehose-nozzle-release/blob/master/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb#L98) uses nozzle.num_workers, while the spec (https://github.com/DataDog/datadog-firehose-nozzle-release/blob/master/jobs/datadog-firehose-nozzle/spec#L123) used nozzle.workers property name.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
