### PR TITLE
[ARTSEC-INT] Update datadog-agent-buildimages to v102144341-64dad9f8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
 
 datadog-firehose-nozzle-release:
   stage: deploy
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v48815877-9bfad02c
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v102144341-64dad9f8
   tags: ['runner:main']
   when: manual
   script:
@@ -33,7 +33,7 @@ datadog-firehose-nozzle-release:
 
 update-go-version:
   stage: deploy
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v48815877-9bfad02c
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy:v102144341-64dad9f8
   tags: ['runner:main']
   when: manual
   variables:


### PR DESCRIPTION
Update stale buildimages reference to v102144341-64dad9f8.