### PR TITLE
Add BOSH tags config to nozzle job spec and ERB template

### DIFF
--- a/jobs/datadog-firehose-nozzle/spec
+++ b/jobs/datadog-firehose-nozzle/spec
@@ -177,3 +177,18 @@ properties:
   nozzle.enable_metadata_app_metrics_prefix:
     default: true
     description: Wheter or not to add "label/" or "annotation/" prefix to app metadata tags in app metrics.
+  nozzle.bosh_tags.enabled:
+    default: false
+    description: Enable BOSH tag generation from envelope metadata (replicates Datadog SaaS log enrichment for CloudPrem/BYOC)
+  nozzle.bosh_tags.friendly_hostname:
+    default: true
+    description: Use a friendly hostname format (job-index) instead of the raw VM GUID
+  nozzle.bosh_tags.unique_friendly_hostname:
+    default: false
+    description: Append deployment name to friendly hostname for uniqueness across deployments
+  nozzle.bosh_tags.friendly_hostname_append_guid:
+    default: false
+    description: Append VM GUID to friendly hostname
+  nozzle.bosh_tags.use_uuid_hostname:
+    default: false
+    description: Use the raw VM GUID as hostname

--- a/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
+++ b/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
@@ -111,11 +111,11 @@ JSON.pretty_generate(
     "EnableAdvancedTagging" => p("nozzle.enable_advanced_tagging"),
     "EnableMetadataAppMetricsPrefix" => p("nozzle.enable_metadata_app_metrics_prefix"),
     "BoshTagsConfig" => {
-        "bosh_tags" => p("nozzle.bosh_tags.enabled", false),
-        "friendly_hostname" => p("nozzle.bosh_tags.friendly_hostname", true),
-        "unique_friendly_hostname" => p("nozzle.bosh_tags.unique_friendly_hostname", false),
-        "friendly_hostname_append_guid" => p("nozzle.bosh_tags.friendly_hostname_append_guid", false),
-        "use_uuid_hostname" => p("nozzle.bosh_tags.use_uuid_hostname", false),
+        "BoshTags" => p("nozzle.bosh_tags.enabled", false),
+        "FriendlyHostname" => p("nozzle.bosh_tags.friendly_hostname", true),
+        "UniqueFriendlyHostname" => p("nozzle.bosh_tags.unique_friendly_hostname", false),
+        "FriendlyHostnameAppendGuid" => p("nozzle.bosh_tags.friendly_hostname_append_guid", false),
+        "UseUuidHostname" => p("nozzle.bosh_tags.use_uuid_hostname", false),
     }
 )
 

--- a/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
+++ b/jobs/datadog-firehose-nozzle/templates/datadog-firehose-nozzle.json.erb
@@ -109,7 +109,14 @@ JSON.pretty_generate(
     "DCAUrl"=>  dca_full_url,
     "DCAToken" => p("nozzle.dca_token", ""),
     "EnableAdvancedTagging" => p("nozzle.enable_advanced_tagging"),
-    "EnableMetadataAppMetricsPrefix" => p("nozzle.enable_metadata_app_metrics_prefix")
+    "EnableMetadataAppMetricsPrefix" => p("nozzle.enable_metadata_app_metrics_prefix"),
+    "BoshTagsConfig" => {
+        "bosh_tags" => p("nozzle.bosh_tags.enabled", false),
+        "friendly_hostname" => p("nozzle.bosh_tags.friendly_hostname", true),
+        "unique_friendly_hostname" => p("nozzle.bosh_tags.unique_friendly_hostname", false),
+        "friendly_hostname_append_guid" => p("nozzle.bosh_tags.friendly_hostname_append_guid", false),
+        "use_uuid_hostname" => p("nozzle.bosh_tags.use_uuid_hostname", false),
+    }
 )
 
 %>


### PR DESCRIPTION
Add nozzle.bosh_tags.* properties (enabled, friendly_hostname, unique_friendly_hostname, friendly_hostname_append_guid, use_uuid_hostname) for CloudPrem log enrichment.

Address and IP tags are always generated by the nozzle (not configurable). Tag prefix is hardcoded to "bosh_". Hostname options reuse the same semantics as the Datadog Agent.
